### PR TITLE
Proper shading.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,8 +133,8 @@
 		</dependency>
 		<dependency>
 			<groupId>de.tr7zw</groupId>
-			<artifactId>item-nbt-api-plugin</artifactId>
-			<version>2.15.5</version>
+			<artifactId>item-nbt-api</artifactId>
+			<version>2.15.6</version>
 		</dependency>
 		<dependency>
 			<groupId>net.dmulloy2</groupId>


### PR DESCRIPTION
- Fix for https://github.com/tr7zw/Item-NBT-API/wiki/Using-Maven#option-2-shading-the-nbt-api-into-your-plugin
- Update shaded version to 2.15.6
